### PR TITLE
Fix the path of binary: /usr/bin -> /usr/local/bin

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Install Caddy with extra features
 
 ###```install_path```
 
-Caddy binary installation path - default /usr/bin
+Caddy binary installation path - default /usr/local/bin
 
 ###```caddy_user```
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -15,7 +15,7 @@ class caddy::params {
 
   case $::osfamily {
     'RedHat':  {
-      $install_path  = '/usr/bin'
+      $install_path  = '/usr/local/bin'
       $caddy_user    = 'caddy'
       $caddy_home    = '/etc/ssl/caddy'
       $caddy_group   = 'caddy'

--- a/spec/classes/package_spec.rb
+++ b/spec/classes/package_spec.rb
@@ -16,7 +16,7 @@ describe 'caddy::package' do
       is_expected.to contain_exec('extract caddy')
     end
     it do
-      is_expected.to contain_file('/usr/bin/caddy').with(
+      is_expected.to contain_file('/usr/local/bin/caddy').with(
         'mode'    => '0755',
         'owner'   => 'root',
         'group'   => 'root',


### PR DESCRIPTION
This module should save the binary at /usr/local/bin, because /usr/bin is used by the os package manager.