### PR TITLE
Fix Caddy download/installs

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -19,13 +19,10 @@ class caddy::install (
 ) {
   assert_private()
 
-  case $version {
-    /^1\./: {
-      $dl_file_name = "caddy_v${version}_linux_${arch}.tar.gz"
-    }
-    default: {
-      $dl_file_name = "caddy_${version}_linux_${arch}.tar.gz"
-    }
+  if $version =~ /^1\./ {
+    $dl_file_name = "caddy_v${version}_linux_${arch}.tar.gz"
+  } else {
+    $dl_file_name = "caddy_${version}_linux_${arch}.tar.gz"
   }
 
   case $install_method {

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -20,15 +20,24 @@ class caddy::install (
 
   assert_private()
 
+  case $version {
+    /^1\./: {
+      $dl_file_name = "caddy_v${version}_linux_${arch}.tar.gz"
+    }
+    default: {
+      $dl_file_name = "caddy_${version}_linux_${arch}.tar.gz"
+    }
+  }
+
   case $install_method {
     'github': {
       $caddy_url    = 'https://github.com/caddyserver/caddy/releases/download'
-      $caddy_dl_url = "${caddy_url}/v${version}/caddy_v${version}_linux_${arch}.tar.gz"
-      $caddy_dl_dir = "${caddy_tmp_dir}/caddy_v${version}_linux_${$arch}.tar.gz"
+      $caddy_dl_url = "${caddy_url}/v${version}/${dl_file_name}"
+      $caddy_dl_dir = "${caddy_tmp_dir}/${dl_file_name}"
     }
     default: {
-      $caddy_url    = 'https://caddyserver.com/download/linux'
-      $caddy_dl_url = "${caddy_url}/${arch}?plugins=${caddy_features}&license=${caddy_license}&telemetry=${caddy_telemetry}"
+      $caddy_url    = 'https://caddyserver.com/api/download'
+      $caddy_dl_url = "${caddy_url}?os=linux&arch=${arch}&plugins=${caddy_features}&license=${caddy_license}&telemetry=${caddy_telemetry}"
       $caddy_dl_dir = "${caddy_tmp_dir}/caddy_linux_${$arch}_custom.tar.gz"
     }
   }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -49,7 +49,7 @@ describe 'caddy' do
             'ensure'       => 'present',
             'extract'      => 'true',
             'extract_path' => '/opt/caddy',
-            'source'       => 'https://caddyserver.com/download/linux/amd64?plugins=http.git,http.filter,http.ipfilter&license=personal&telemetry=off',
+            'source'       => 'https://caddyserver.com/api/download?os=linux&arch=amd64&plugins=http.git,http.filter,http.ipfilter&license=personal&telemetry=off',
             'user'         => 'root',
             'group'        => 'root',
             'creates'      => '/opt/caddy/caddy',
@@ -146,25 +146,50 @@ describe 'caddy' do
       end
 
       context 'with specific version' do
-        let(:params) do
-          {
-            version: '1.0.3',
-            install_method: 'github'
-          }
+        context 'version 1.x' do
+          let(:params) do
+            {
+                version: '1.0.3',
+                install_method: 'github'
+            }
+          end
+
+          it do
+            is_expected.to contain_archive('/tmp/caddy_v1.0.3_linux_amd64.tar.gz').with(
+                'ensure'       => 'present',
+                'extract'      => 'true',
+                'extract_path' => '/opt/caddy',
+                'source'       => 'https://github.com/caddyserver/caddy/releases/download/v1.0.3/caddy_v1.0.3_linux_amd64.tar.gz',
+                'user'         => 'root',
+                'group'        => 'root',
+                'creates'      => '/opt/caddy/caddy',
+                'cleanup'      => 'true',
+                'notify'       => 'File_capability[/opt/caddy/caddy]'
+            )
+          end
         end
 
-        it do
-          is_expected.to contain_archive('/tmp/caddy_v1.0.3_linux_amd64.tar.gz').with(
-            'ensure'       => 'present',
-            'extract'      => 'true',
-            'extract_path' => '/opt/caddy',
-            'source'       => 'https://github.com/caddyserver/caddy/releases/download/v1.0.3/caddy_v1.0.3_linux_amd64.tar.gz',
-            'user'         => 'root',
-            'group'        => 'root',
-            'creates'      => '/opt/caddy/caddy',
-            'cleanup'      => 'true',
-            'notify'       => 'File_capability[/opt/caddy/caddy]'
-          )
+        context 'version 2.x' do
+          let(:params) do
+            {
+                version: '2.2.0',
+                install_method: 'github'
+            }
+          end
+
+          it do
+            is_expected.to contain_archive('/tmp/caddy_2.2.0_linux_amd64.tar.gz').with(
+                'ensure'       => 'present',
+                'extract'      => 'true',
+                'extract_path' => '/opt/caddy',
+                'source'       => 'https://github.com/caddyserver/caddy/releases/download/v2.2.0/caddy_2.2.0_linux_amd64.tar.gz',
+                'user'         => 'root',
+                'group'        => 'root',
+                'creates'      => '/opt/caddy/caddy',
+                'cleanup'      => 'true',
+                'notify'       => 'File_capability[/opt/caddy/caddy]'
+            )
+          end
         end
       end
     end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -45,18 +45,14 @@ describe 'caddy' do
           )
         end
         it do
-          is_expected.to contain_archive('/tmp/caddy_linux_amd64_custom.tar.gz').with(
-            'ensure'       => 'present',
-            'extract'      => 'true',
-            'extract_path' => '/opt/caddy',
-            'source'       => 'https://caddyserver.com/api/download?os=linux&arch=amd64&plugins=http.git,http.filter,http.ipfilter&license=personal&telemetry=off',
-            'user'         => 'root',
-            'group'        => 'root',
-            'creates'      => '/opt/caddy/caddy',
-            'cleanup'      => 'true',
-            'notify'       => 'File_capability[/opt/caddy/caddy]',
-            'require'      => 'File[/opt/caddy]'
-          )
+          is_expected.to contain_file('/opt/caddy/caddy').with(
+              'ensure'  => 'file',
+              'owner'   => 'root',
+              'group'   => 'root',
+              'source'  => 'https://caddyserver.com/api/download?os=linux&arch=amd64&plugins=http.git,http.filter,http.ipfilter&license=personal&telemetry=off',
+              'notify'  => 'File_capability[/opt/caddy/caddy]',
+              'require' => 'File[/opt/caddy]'
+              )
         end
         it do
           is_expected.to contain_file_capability('/opt/caddy/caddy').with(
@@ -145,7 +141,7 @@ describe 'caddy' do
         end
       end
 
-      context 'with specific version' do
+      context 'using github install method' do
         context 'version 1.x' do
           let(:params) do
             {


### PR DESCRIPTION
#### Pull Request (PR) description
Updates to installation methods:
* Support downloading 2.x releases from GitHub by generating correct release tarball name
* Fix 404 error when using the caddy download service
