### PR TITLE
Fix typo on installing package from github

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -24,7 +24,7 @@ class caddy::install (
     'github': {
       $caddy_url    = 'https://github.com/caddyserver/caddy/releases/download'
       $caddy_dl_url = "${caddy_url}/v${version}/caddy_v${version}_linux_${arch}.tar.gz"
-      $caddy_dl_dir = "${caddy_tmp_dir}/caddy_v${version}_linux_${$arch}.tar.gz"
+      $caddy_dl_dir = "${caddy_tmp_dir}/caddy_${version}_linux_${$arch}.tar.gz"
     }
     default: {
       $caddy_url    = 'https://caddyserver.com/download/linux'


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Fix archive location when installing from Github
Installation fails when using Github as a source for the archive, because of extra `v` when defining the version. 


#### This Pull Request (PR) fixes the following issues
Fixes #75 
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
