### PR TITLE
Make sure acceptance tests are idempotent

### DIFF
--- a/spec/acceptance/init_spec.rb
+++ b/spec/acceptance/init_spec.rb
@@ -3,49 +3,44 @@
 require 'spec_helper_acceptance'
 
 describe 'class caddy:' do
-  context 'with defaults:' do
-    pp = 'include caddy'
-    it 'runs successfully' do
-      apply_manifest(pp, catch_failures: true) do |r|
-        expect(r.stderr).not_to match(%r{error}i)
-      end
-    end
-
-    it 'runs without changes' do
-      apply_manifest(pp, catch_failures: true) do |r|
-        expect(r.exit_code).to be_zero
+  context 'with default settings' do
+    it_behaves_like 'an idempotent resource' do
+      let(:manifest) do
+        <<~PUPPET
+          class { 'caddy':
+          }
+        PUPPET
       end
     end
   end
 
-  context 'from github:' do
-    pp = "class { 'caddy':
+  context 'when installing from GitHub' do
+    it_behaves_like 'an idempotent resource' do
+      let(:manifest) do
+        <<~PUPPET
+          class { 'caddy':
             install_method => 'github',
-          }"
-    it 'installs successfully' do
-      apply_manifest(pp, catch_failures: true) do |r|
-        expect(r.stderr).not_to match(%r{error}i)
+          }
+        PUPPET
       end
     end
   end
 
   context 'with vhosts' do
-    pp = "include caddy
+    it_behaves_like 'an idempotent resource' do
+      let(:manifest) do
+        <<~PUPPET
+          class { 'caddy':
+          }
+
           caddy::vhost {'example1':
             source => 'puppet:///modules/caddy/etc/caddy/config/example1.conf',
           }
+
           caddy::vhost {'example2':
             source => 'puppet:///modules/caddy/etc/caddy/config/example2.conf',
-          }"
-    it 'runs successfully' do
-      apply_manifest(pp, catch_failures: true) do |r|
-        expect(r.stderr).not_to match(%r{error}i)
-      end
-    end
-
-    it 'runs without changes' do
-      apply_manifest(pp, catch_failures: true) do |r|
-        expect(r.exit_code).to be_zero
+          }
+        PUPPET
       end
     end
   end


### PR DESCRIPTION
Rely on voxpupuli-acceptance helper to ensure our test catalogs are working as expected.
