### PR TITLE
Rework capabilities management

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,6 +1,5 @@
 fixtures:
   repositories:
     archive: https://github.com/voxpupuli/puppet-archive.git
-    file_capability: https://github.com/smoeding/puppet-file_capability.git
     stdlib: https://github.com/puppetlabs/puppetlabs-stdlib.git
     systemd: https://github.com/voxpupuli/puppet-systemd.git

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -231,11 +231,11 @@ Default value: `undef`
 
 ##### <a name="-caddy--systemd_ambient_capabilities"></a>`systemd_ambient_capabilities`
 
-Data type: `Optional[String[1]]`
+Data type: `String[1]`
 
 Controls which capabilities to include in the ambient capability set for the executed process.
 
-Default value: `undef`
+Default value: `'CAP_NET_BIND_SERVICE'`
 
 ##### <a name="-caddy--systemd_no_new_privileges"></a>`systemd_no_new_privileges`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -98,7 +98,7 @@ class caddy (
   Integer[0]                     $systemd_limit_processes         = 64,
   Boolean                        $systemd_private_devices         = true,
   Optional[String[1]]            $systemd_capability_bounding_set = undef,
-  Optional[String[1]]            $systemd_ambient_capabilities    = undef,
+  String[1]                      $systemd_ambient_capabilities    = 'CAP_NET_BIND_SERVICE',
   Optional[Boolean]              $systemd_no_new_privileges       = undef,
 ) {
   case $caddy_architecture {

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -24,7 +24,6 @@ class caddy::install {
       group        => 'root',
       creates      => $bin_file,
       cleanup      => true,
-      notify       => File_capability[$bin_file],
       require      => File[$caddy::install_path],
     }
   } else {
@@ -38,7 +37,6 @@ class caddy::install {
       mode    => '0755',
       source  => $caddy_dl_url,
       replace => false, # Don't download the file on every run
-      notify  => File_capability[$bin_file],
     }
   }
 
@@ -47,11 +45,5 @@ class caddy::install {
     owner  => $caddy::caddy_user,
     group  => $caddy::caddy_group,
     mode   => '0755',
-  }
-
-  include file_capability
-  file_capability { $bin_file:
-    ensure     => present,
-    capability => 'cap_net_bind_service=ep',
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -19,10 +19,6 @@
     {
       "name": "puppetlabs/stdlib",
       "version_requirement": ">= 4.25.0 < 10.0.0"
-    },
-    {
-      "name": "stm/file_capability",
-      "version_requirement": ">= 3.0.0 < 7.0.0"
     }
   ],
   "operatingsystem_support": [

--- a/spec/acceptance/init_spec.rb
+++ b/spec/acceptance/init_spec.rb
@@ -3,49 +3,44 @@
 require 'spec_helper_acceptance'
 
 describe 'class caddy:' do
-  context 'with defaults:' do
-    pp = 'include caddy'
-    it 'runs successfully' do
-      apply_manifest(pp, catch_failures: true) do |r|
-        expect(r.stderr).not_to match(%r{error}i)
-      end
-    end
-
-    it 'runs without changes' do
-      apply_manifest(pp, catch_failures: true) do |r|
-        expect(r.exit_code).to be_zero
+  context 'with default settings' do
+    it_behaves_like 'an idempotent resource' do
+      let(:manifest) do
+        <<~PUPPET
+          class { 'caddy':
+          }
+        PUPPET
       end
     end
   end
 
-  context 'from github:' do
-    pp = "class { 'caddy':
+  context 'when installing from GitHub' do
+    it_behaves_like 'an idempotent resource' do
+      let(:manifest) do
+        <<~PUPPET
+          class { 'caddy':
             install_method => 'github',
-          }"
-    it 'installs successfully' do
-      apply_manifest(pp, catch_failures: true) do |r|
-        expect(r.stderr).not_to match(%r{error}i)
+          }
+        PUPPET
       end
     end
   end
 
   context 'with vhosts' do
-    pp = "include caddy
+    it_behaves_like 'an idempotent resource' do
+      let(:manifest) do
+        <<~PUPPET
+          class { 'caddy':
+          }
+
           caddy::vhost {'example1':
             source => 'puppet:///modules/caddy/etc/caddy/config/example1.conf',
           }
+
           caddy::vhost {'example2':
             source => 'puppet:///modules/caddy/etc/caddy/config/example2.conf',
-          }"
-    it 'runs successfully' do
-      apply_manifest(pp, catch_failures: true) do |r|
-        expect(r.stderr).not_to match(%r{error}i)
-      end
-    end
-
-    it 'runs without changes' do
-      apply_manifest(pp, catch_failures: true) do |r|
-        expect(r.exit_code).to be_zero
+          }
+        PUPPET
       end
     end
   end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -57,15 +57,7 @@ describe 'caddy' do
             with_mode('0755').
             with_source('https://caddyserver.com/api/download?os=linux&arch=amd64&plugins=http.git,http.filter,http.ipfilter&license=personal&telemetry=off').
             with_replace(false).
-            that_notifies('File_capability[/opt/caddy/caddy]').
             that_requires('File[/opt/caddy]')
-        end
-
-        it do
-          expect(subject).to contain_file_capability('/opt/caddy/caddy').with(
-            'ensure' => 'present',
-            'capability' => 'cap_net_bind_service=ep'
-          ).that_subscribes_to('File[/opt/caddy/caddy]')
         end
 
         it do
@@ -159,8 +151,7 @@ describe 'caddy' do
             'creates' => '/opt/caddy/caddy',
             'cleanup' => 'true'
           ).
-            that_requires('File[/opt/caddy]').
-            that_notifies('File_capability[/opt/caddy/caddy]')
+            that_requires('File[/opt/caddy]')
         end
       end
     end


### PR DESCRIPTION
Setting capabilities on the binary works fine in docker but the acceptance tests fail when running in Vagrant.  While trying to identify the root cause of the issue, it feels inadequate to set the capabilities on the binary itself because it allows any user on the system to run caddy and attach it on a privileged port.

Removing the explicit file capabilities management and passing this responsibility to systemd helps solving the above issue, and also fix running the acceptance tests in Vagrant.

Fixes #91 

Also include:

* #90 
