### PR TITLE
Do not cache files in /tmp & remove stm/file_capability dependency

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,6 +1,5 @@
 fixtures:
   repositories:
     archive: https://github.com/voxpupuli/puppet-archive.git
-    file_capability: https://github.com/smoeding/puppet-file_capability.git
     stdlib: https://github.com/puppetlabs/puppetlabs-stdlib.git
     systemd: https://github.com/voxpupuli/puppet-systemd.git

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -231,11 +231,11 @@ Default value: `undef`
 
 ##### <a name="-caddy--systemd_ambient_capabilities"></a>`systemd_ambient_capabilities`
 
-Data type: `Optional[String[1]]`
+Data type: `String[1]`
 
 Controls which capabilities to include in the ambient capability set for the executed process.
 
-Default value: `undef`
+Default value: `'CAP_NET_BIND_SERVICE'`
 
 ##### <a name="-caddy--systemd_no_new_privileges"></a>`systemd_no_new_privileges`
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -62,7 +62,6 @@ The following parameters are available in the `caddy` class:
 * [`caddy_group`](#-caddy--caddy_group)
 * [`caddy_shell`](#-caddy--caddy_shell)
 * [`caddy_log_dir`](#-caddy--caddy_log_dir)
-* [`caddy_tmp_dir`](#-caddy--caddy_tmp_dir)
 * [`caddy_home`](#-caddy--caddy_home)
 * [`caddy_ssl_dir`](#-caddy--caddy_ssl_dir)
 * [`caddy_license`](#-caddy--caddy_license)
@@ -132,14 +131,6 @@ Data type: `Stdlib::Absolutepath`
 Directory where the log files are stored.
 
 Default value: `'/var/log/caddy'`
-
-##### <a name="-caddy--caddy_tmp_dir"></a>`caddy_tmp_dir`
-
-Data type: `Stdlib::Absolutepath`
-
-Directory where the Caddy archive is stored.
-
-Default value: `'/tmp'`
 
 ##### <a name="-caddy--caddy_home"></a>`caddy_home`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -36,9 +36,6 @@
 # @param caddy_log_dir
 #   Directory where the log files are stored.
 #
-# @param caddy_tmp_dir
-#   Directory where the Caddy archive is stored.
-#
 # @param caddy_home
 #   Directory where the Caddy data is stored.
 #
@@ -86,7 +83,6 @@ class caddy (
   String[1]                      $caddy_group                     = 'caddy',
   Stdlib::Absolutepath           $caddy_shell                     = '/sbin/nologin',
   Stdlib::Absolutepath           $caddy_log_dir                   = '/var/log/caddy',
-  Stdlib::Absolutepath           $caddy_tmp_dir                   = '/tmp',
   Stdlib::Absolutepath           $caddy_home                      = '/var/lib/caddy',
   Stdlib::Absolutepath           $caddy_ssl_dir                   = '/etc/ssl/caddy',
   Enum['personal', 'commercial'] $caddy_license                   = 'personal',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -98,7 +98,7 @@ class caddy (
   Integer[0]                     $systemd_limit_processes         = 64,
   Boolean                        $systemd_private_devices         = true,
   Optional[String[1]]            $systemd_capability_bounding_set = undef,
-  Optional[String[1]]            $systemd_ambient_capabilities    = undef,
+  String[1]                      $systemd_ambient_capabilities    = 'CAP_NET_BIND_SERVICE',
   Optional[Boolean]              $systemd_no_new_privileges       = undef,
 ) {
   case $caddy_architecture {

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -24,7 +24,6 @@ class caddy::install {
       group        => 'root',
       creates      => $bin_file,
       cleanup      => true,
-      notify       => File_capability[$bin_file],
       require      => File[$caddy::install_path],
     }
   } else {
@@ -38,7 +37,6 @@ class caddy::install {
       mode    => '0755',
       source  => $caddy_dl_url,
       replace => false, # Don't download the file on every run
-      notify  => File_capability[$bin_file],
     }
   }
 
@@ -47,11 +45,5 @@ class caddy::install {
     owner  => $caddy::caddy_user,
     group  => $caddy::caddy_group,
     mode   => '0755',
-  }
-
-  include file_capability
-  file_capability { $bin_file:
-    ensure     => present,
-    capability => 'cap_net_bind_service=ep',
   }
 }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -11,9 +11,9 @@ class caddy::install {
   if $caddy::install_method == 'github' {
     $caddy_url    = 'https://github.com/caddyserver/caddy/releases/download'
     $caddy_dl_url = "${caddy_url}/v${caddy::version}/caddy_${caddy::version}_linux_${caddy::arch}.tar.gz"
-    $caddy_dl_dir = "${caddy::caddy_tmp_dir}/caddy_${caddy::version}_linux_${$caddy::arch}.tar.gz"
+    $caddy_dl_dir = "/var/cache/caddy_${caddy::version}_linux_${$caddy::arch}.tar.gz"
 
-    $extract_path = "${caddy::caddy_tmp_dir}/caddy-${caddy::version}"
+    $extract_path = "/var/cache/caddy-${caddy::version}"
 
     file { $extract_path:
       ensure => directory,
@@ -35,12 +35,12 @@ class caddy::install {
       before       => File[$bin_file],
     }
 
-    $caddy_source = "${caddy::caddy_tmp_dir}/caddy-${caddy::version}/caddy"
+    $caddy_source = "/var/cache/caddy-${caddy::version}/caddy"
   } else {
     $caddy_url    = 'https://caddyserver.com/api/download'
     $caddy_dl_url = "${caddy_url}?os=linux&arch=${caddy::arch}&plugins=${caddy::caddy_features}&license=${caddy::caddy_license}&telemetry=${caddy::caddy_telemetry}"
 
-    $caddy_source = "${caddy::caddy_tmp_dir}/caddy-latest"
+    $caddy_source = '/var/cache/caddy-latest'
 
     file { $caddy_source:
       ensure  => file,

--- a/metadata.json
+++ b/metadata.json
@@ -19,10 +19,6 @@
     {
       "name": "puppetlabs/stdlib",
       "version_requirement": ">= 4.25.0 < 10.0.0"
-    },
-    {
-      "name": "stm/file_capability",
-      "version_requirement": ">= 3.0.0 < 7.0.0"
     }
   ],
   "operatingsystem_support": [

--- a/spec/acceptance/init_spec.rb
+++ b/spec/acceptance/init_spec.rb
@@ -3,49 +3,44 @@
 require 'spec_helper_acceptance'
 
 describe 'class caddy:' do
-  context 'with defaults:' do
-    pp = 'include caddy'
-    it 'runs successfully' do
-      apply_manifest(pp, catch_failures: true) do |r|
-        expect(r.stderr).not_to match(%r{error}i)
-      end
-    end
-
-    it 'runs without changes' do
-      apply_manifest(pp, catch_failures: true) do |r|
-        expect(r.exit_code).to be_zero
+  context 'with default settings' do
+    it_behaves_like 'an idempotent resource' do
+      let(:manifest) do
+        <<~PUPPET
+          class { 'caddy':
+          }
+        PUPPET
       end
     end
   end
 
-  context 'from github:' do
-    pp = "class { 'caddy':
+  context 'when installing from GitHub' do
+    it_behaves_like 'an idempotent resource' do
+      let(:manifest) do
+        <<~PUPPET
+          class { 'caddy':
             install_method => 'github',
-          }"
-    it 'installs successfully' do
-      apply_manifest(pp, catch_failures: true) do |r|
-        expect(r.stderr).not_to match(%r{error}i)
+          }
+        PUPPET
       end
     end
   end
 
   context 'with vhosts' do
-    pp = "include caddy
+    it_behaves_like 'an idempotent resource' do
+      let(:manifest) do
+        <<~PUPPET
+          class { 'caddy':
+          }
+
           caddy::vhost {'example1':
             source => 'puppet:///modules/caddy/etc/caddy/config/example1.conf',
           }
+
           caddy::vhost {'example2':
             source => 'puppet:///modules/caddy/etc/caddy/config/example2.conf',
-          }"
-    it 'runs successfully' do
-      apply_manifest(pp, catch_failures: true) do |r|
-        expect(r.stderr).not_to match(%r{error}i)
-      end
-    end
-
-    it 'runs without changes' do
-      apply_manifest(pp, catch_failures: true) do |r|
-        expect(r.exit_code).to be_zero
+          }
+        PUPPET
       end
     end
   end

--- a/spec/acceptance/init_spec.rb
+++ b/spec/acceptance/init_spec.rb
@@ -2,6 +2,12 @@
 
 require 'spec_helper_acceptance'
 
+# The default configuration download the latest available release. In order to
+# avoid to maintain the test suite to match each release, query GitHub API to
+# find the last release.
+latest_release = JSON.parse(URI.open('https://api.github.com/repos/caddyserver/caddy/releases/latest').read)['tag_name']
+
+# rubocop:disable RSpec/RepeatedExampleGroupDescription
 describe 'class caddy:' do
   context 'with default settings' do
     it_behaves_like 'an idempotent resource' do
@@ -12,6 +18,10 @@ describe 'class caddy:' do
         PUPPET
       end
     end
+
+    describe command('/opt/caddy/caddy version') do
+      its(:stdout) { is_expected.to start_with latest_release }
+    end
   end
 
   context 'when installing from GitHub' do
@@ -20,9 +30,29 @@ describe 'class caddy:' do
         <<~PUPPET
           class { 'caddy':
             install_method => 'github',
+            version        => '2.6.0',
           }
         PUPPET
       end
+    end
+
+    describe command('/opt/caddy/caddy version') do
+      its(:stdout) { is_expected.to start_with 'v2.6.0' }
+    end
+
+    it_behaves_like 'an idempotent resource' do
+      let(:manifest) do
+        <<~PUPPET
+          class { 'caddy':
+            install_method => 'github',
+            version        => '#{latest_release.sub(%r{\Av}, '')}',
+          }
+        PUPPET
+      end
+    end
+
+    describe command('/opt/caddy/caddy version') do
+      its(:stdout) { is_expected.to start_with latest_release }
     end
   end
 
@@ -45,3 +75,4 @@ describe 'class caddy:' do
     end
   end
 end
+# rubocop:enable RSpec/RepeatedExampleGroupDescription

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -57,15 +57,7 @@ describe 'caddy' do
             with_mode('0755').
             with_source('https://caddyserver.com/api/download?os=linux&arch=amd64&plugins=http.git,http.filter,http.ipfilter&license=personal&telemetry=off').
             with_replace(false).
-            that_notifies('File_capability[/opt/caddy/caddy]').
             that_requires('File[/opt/caddy]')
-        end
-
-        it do
-          expect(subject).to contain_file_capability('/opt/caddy/caddy').with(
-            'ensure' => 'present',
-            'capability' => 'cap_net_bind_service=ep'
-          ).that_subscribes_to('File[/opt/caddy/caddy]')
         end
 
         it do
@@ -159,8 +151,7 @@ describe 'caddy' do
             'creates' => '/opt/caddy/caddy',
             'cleanup' => 'true'
           ).
-            that_requires('File[/opt/caddy]').
-            that_notifies('File_capability[/opt/caddy/caddy]')
+            that_requires('File[/opt/caddy]')
         end
       end
     end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -50,7 +50,7 @@ describe 'caddy' do
         end
 
         it do
-          expect(subject).to contain_file('/tmp/caddy-latest').
+          expect(subject).to contain_file('/var/cache/caddy-latest').
             with_ensure('file').
             with_owner('root').
             with_group('root').
@@ -65,7 +65,7 @@ describe 'caddy' do
             with_owner('root').
             with_group('root').
             with_mode('0755').
-            with_source('/tmp/caddy-latest').
+            with_source('/var/cache/caddy-latest').
             that_requires('File[/opt/caddy]')
         end
 
@@ -150,10 +150,10 @@ describe 'caddy' do
         end
 
         it do
-          expect(subject).to contain_archive('/tmp/caddy_2.0.0_linux_amd64.tar.gz').with(
+          expect(subject).to contain_archive('/var/cache/caddy_2.0.0_linux_amd64.tar.gz').with(
             'ensure' => 'present',
             'extract' => 'true',
-            'extract_path' => '/tmp/caddy-2.0.0',
+            'extract_path' => '/var/cache/caddy-2.0.0',
             'source' => 'https://github.com/caddyserver/caddy/releases/download/v2.0.0/caddy_2.0.0_linux_amd64.tar.gz',
             'user' => 'root',
             'group' => 'root'
@@ -166,7 +166,7 @@ describe 'caddy' do
             with_owner('root').
             with_group('root').
             with_mode('0755').
-            with_source('/tmp/caddy-2.0.0/caddy').
+            with_source('/var/cache/caddy-2.0.0/caddy').
             that_requires('File[/opt/caddy]')
         end
       end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -50,13 +50,22 @@ describe 'caddy' do
         end
 
         it do
-          expect(subject).to contain_file('/opt/caddy/caddy').
+          expect(subject).to contain_file('/tmp/caddy-latest').
             with_ensure('file').
             with_owner('root').
             with_group('root').
             with_mode('0755').
             with_source('https://caddyserver.com/api/download?os=linux&arch=amd64&plugins=http.git,http.filter,http.ipfilter&license=personal&telemetry=off').
-            with_replace(false).
+            with_replace(false)
+        end
+
+        it do
+          expect(subject).to contain_file('/opt/caddy/caddy').
+            with_ensure('file').
+            with_owner('root').
+            with_group('root').
+            with_mode('0755').
+            with_source('/tmp/caddy-latest').
             that_requires('File[/opt/caddy]')
         end
 
@@ -144,13 +153,20 @@ describe 'caddy' do
           expect(subject).to contain_archive('/tmp/caddy_2.0.0_linux_amd64.tar.gz').with(
             'ensure' => 'present',
             'extract' => 'true',
-            'extract_path' => '/opt/caddy',
+            'extract_path' => '/tmp/caddy-2.0.0',
             'source' => 'https://github.com/caddyserver/caddy/releases/download/v2.0.0/caddy_2.0.0_linux_amd64.tar.gz',
             'user' => 'root',
-            'group' => 'root',
-            'creates' => '/opt/caddy/caddy',
-            'cleanup' => 'true'
-          ).
+            'group' => 'root'
+          )
+        end
+
+        it do
+          expect(subject).to contain_file('/opt/caddy/caddy').
+            with_ensure('file').
+            with_owner('root').
+            with_group('root').
+            with_mode('0755').
+            with_source('/tmp/caddy-2.0.0/caddy').
             that_requires('File[/opt/caddy]')
         end
       end


### PR DESCRIPTION
The "intermediate" downloaded files needed to unbreak version change are intended to be preserved between reboots.  Drop the `caddy::caddy_tmp_dir` parameter and store cached downloads in `/var/cache` instead of the temporary directory.  

Also include:

* #90
* #93
* #95
