### PR TITLE
Require a version when installing from GitHub

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -110,11 +110,11 @@ The following parameters are available in the `caddy` class:
 
 ##### <a name="-caddy--version"></a>`version`
 
-Data type: `String[1]`
+Data type: `Optional[String[1]]`
 
-Which version is used.
+Which version of caddy to install when install_method is github.
 
-Default value: `'2.0.0'`
+Default value: `undef`
 
 ##### <a name="-caddy--install_method"></a>`install_method`
 
@@ -353,11 +353,11 @@ Default value: `'caddy'`
 
 ##### <a name="-caddy--package_ensure"></a>`package_ensure`
 
-Data type: `String[1]`
+Data type: `Optional[String[1]]`
 
 Whether to install or remove the caddy package. Only relevant when $install_method is 'repo'.
 
-Default value: `$version`
+Default value: `undef`
 
 ##### <a name="-caddy--manage_caddyfile"></a>`manage_caddyfile`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -16,7 +16,7 @@
 #   }
 #
 # @param version
-#   Which version is used.
+#   Which version of caddy to install when install_method is github.
 #
 # @param install_method
 #   Which source to use for the Caddy installation. See https://caddyserver.com/docs/install.
@@ -162,7 +162,8 @@
 #   Hash of virtual hosts to create.
 #
 class caddy (
-  String[1]                      $version                         = '2.0.0',
+  Optional[String[1]]            $package_ensure                  = undef,
+  Optional[String[1]]            $version                         = undef,
   Optional[Enum['github','repo']] $install_method                 = undef,
   Stdlib::Absolutepath           $install_path                    = '/opt/caddy',
   Boolean                        $manage_user                     = true,
@@ -196,7 +197,6 @@ class caddy (
   Boolean                        $manage_repo                     = true,
   Hash[String[1],Any]            $repo_settings                   = {},
   String[1]                      $package_name                    = 'caddy',
-  String[1]                      $package_ensure                  = $version,
   Boolean                        $manage_caddyfile                = true,
   Optional[Stdlib::Filesource]   $caddyfile_source                = undef,
   Optional[String[1]]            $caddyfile_content               = undef,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -9,8 +9,16 @@ class caddy::install {
   $bin_file = "${caddy::install_path}/caddy"
 
   case $caddy::install_method {
-    'repo': { contain caddy::install::repo }
+    'repo': {
+      if $caddy::version {
+        fail('caddy::version can only be set when caddy::install_method is github')
+      }
+      contain caddy::install::repo
+    }
     'github': {
+      if !$caddy::version {
+        fail('caddy::version must be set when caddy::install_method is github')
+      }
       $caddy_url    = 'https://github.com/caddyserver/caddy/releases/download'
       $caddy_dl_url = "${caddy_url}/v${caddy::version}/caddy_${caddy::version}_linux_${caddy::arch}.tar.gz"
       $caddy_dl_dir = "/var/cache/caddy_${caddy::version}_linux_${$caddy::arch}.tar.gz"

--- a/spec/acceptance/init_spec.rb
+++ b/spec/acceptance/init_spec.rb
@@ -73,7 +73,7 @@ describe 'class caddy:' do
         <<~PUPPET
           class { 'caddy':
             install_method => 'repo',
-            version        => '#{use_version}',
+            package_ensure => '#{use_version}',
           }
         PUPPET
       end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -3,13 +3,13 @@
 require 'spec_helper'
 
 describe 'caddy' do
-  on_supported_os.each do |os, facts|
-    context "on #{os} with Facter #{facts[:facterversion]} and Puppet #{facts[:puppetversion]}" do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os} with Facter #{os_facts[:facterversion]} and Puppet #{os_facts[:puppetversion]}" do
       let(:facts) do
-        facts
+        os_facts
       end
 
-      case facts[:os]['family']
+      case os_facts[:os]['family']
       when 'Debian'
         caddy_shell = '/usr/sbin/nologin'
         has_repo = true
@@ -180,7 +180,7 @@ describe 'caddy' do
       context 'with install_method => repo' do
         let(:params) { { install_method: 'repo' } }
 
-        case facts[:os]['family']
+        case os_facts[:os]['family']
         when 'Debian'
           context 'on Debian family' do
             it { is_expected.to contain_class('apt') }
@@ -211,7 +211,7 @@ describe 'caddy' do
                 that_comes_before('Package[caddy]')
             end
 
-            it { is_expected.to contain_package('caddy').with_ensure('2.0.0') }
+            it { is_expected.to contain_package('caddy').with_ensure('installed') }
 
             context 'with manage_repo => false' do
               let(:params) { super().merge(manage_repo: false) }
@@ -230,7 +230,7 @@ describe 'caddy' do
                 that_comes_before('Package[caddy]')
             end
 
-            it { is_expected.to contain_package('caddy').with_ensure('2.0.0') }
+            it { is_expected.to contain_package('caddy').with_ensure('installed') }
 
             context 'with manage_repo => false' do
               let(:params) { super().merge(manage_repo: false) }
@@ -252,7 +252,7 @@ describe 'caddy' do
           context 'with package_name => test' do
             let(:params) { super().merge(package_name: 'test') }
 
-            it { is_expected.to contain_package('test').with_ensure('2.0.0') }
+            it { is_expected.to contain_package('test').with_ensure('installed') }
           end
 
           context 'with package_ensure => 2.3.4' do


### PR DESCRIPTION
The `caddy::version` parameter is only used when `caddy::install_method` is "github", but no error was previously raised if the user set a specific version that was ignored, and the resulting configuration was not what the user expected.

In order to avoid confusion, do not default to an outdated version of caddy when installing from GitHub (requiring the user to explicitly tell which version they want) and raise an error if a version is set but is ignored.

This should make the module more user-friendly for new users.

Fixes #94 