### PR TITLE
Remove legacy top-scope syntax

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -78,11 +78,11 @@ The following parameters are available in the `caddy` class:
 
 ##### <a name="-caddy--version"></a>`version`
 
-Data type: `String[1]`
+Data type: `Optional[String[1]]`
 
-Which version is used.
+Which version of caddy to install when install_method is github.
 
-Default value: `'2.0.0'`
+Default value: `undef`
 
 ##### <a name="-caddy--install_method"></a>`install_method`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -16,7 +16,7 @@
 #   }
 #
 # @param version
-#   Which version is used.
+#   Which version of caddy to install when install_method is github.
 #
 # @param install_method
 #   Which source is used.
@@ -76,7 +76,7 @@
 #   Whether the process and all its children can gain new privileges through execve().
 #
 class caddy (
-  String[1]                      $version                         = '2.0.0',
+  Optional[String[1]]            $version                         = undef,
   Optional[Enum['github']]       $install_method                  = undef,
   Stdlib::Absolutepath           $install_path                    = '/opt/caddy',
   String[1]                      $caddy_user                      = 'caddy',

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -9,6 +9,10 @@ class caddy::install {
   $bin_file = "${caddy::install_path}/caddy"
 
   if $caddy::install_method == 'github' {
+    if !$caddy::version {
+      fail('caddy::version must be set when caddy::install_method is github')
+    }
+
     $caddy_url    = 'https://github.com/caddyserver/caddy/releases/download'
     $caddy_dl_url = "${caddy_url}/v${caddy::version}/caddy_${caddy::version}_linux_${caddy::arch}.tar.gz"
     $caddy_dl_dir = "/var/cache/caddy_${caddy::version}_linux_${$caddy::arch}.tar.gz"
@@ -37,6 +41,10 @@ class caddy::install {
 
     $caddy_source = "/var/cache/caddy-${caddy::version}/caddy"
   } else {
+    if $caddy::version {
+      fail('caddy::version can only be set when caddy::install_method is github')
+    }
+
     $caddy_url    = 'https://caddyserver.com/api/download'
     $caddy_dl_url = "${caddy_url}?os=linux&arch=${caddy::arch}&plugins=${caddy::caddy_features}&license=${caddy::caddy_license}&telemetry=${caddy::caddy_telemetry}"
 


### PR DESCRIPTION
The `caddy::version` parameter is only used when `caddy::install_method`
is "github", but no error was previously raised if the user set a
specific version that was ignored, and the resulting configuration was
not what the user expected.

In order to avoid confusion, do not default to an outdated version of
caddy when installing from GitHub (requiring the user to explicily tell
which version they want) and raise an error if a version is set but is
ignored.

This should make the module more user-friendly for new users.
