### PR TITLE
Bump puppet-archive version upper boundary and fix github download idempotency

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -31,6 +31,7 @@ class caddy::install {
       password     => $caddy::caddy_api_key,
       user         => 'root',
       group        => 'root',
+      creates      => "${extract_path}/caddy",
       require      => File[$extract_path],
       before       => File[$bin_file],
     }

--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,7 @@
     },
     {
       "name": "puppet/archive",
-      "version_requirement": ">= 4.4.0 < 6.0.0"
+      "version_requirement": ">= 4.4.0 < 8.0.0"
     },
     {
       "name": "puppetlabs/stdlib",


### PR DESCRIPTION
Cleanup issue https://github.com/voxpupuli/puppet-archive/pull/474 was fixed in puppet-archive v6.1.2. That reveals hidden idempotency issue in this module. This PR fixes that by using `creates` archive parameter.
