### PR TITLE
Implement vhost_dir and vhost_enable_dir support

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,56 @@ caddy::vhost { 'example2':
 }
 ```
 
+Use `conf.d` + `sites-available` + `sites-enabled` layout with `config_files` and `vhosts` parameters set:
+
+```puppet
+class { 'caddy':
+  config_dir => '/etc/caddy/conf.d',
+  vhost_dir => '/etc/caddy/sites-available',
+  vhost_enable_dir => '/etc/caddy/sites-enabled',
+  config_files => {
+    admin_port_2020 => {
+      content => "{\n  admin localhost:2020\n}\n",
+    },
+  },
+  vhosts => {
+    port_3000 => {
+      content => "http://localhost:3000 {\n  respond \\"port 3000\\"\n}\n",
+    },
+    port_3001 => {
+      ensure => 'disabled',
+      content => "http://localhost:3001 {\n  respond \\"port 3001\\"\n}\n",
+    }
+  }
+}
+```
+
+Same as above but configured in Hiera:
+
+```yaml
+caddy::config_dir: /etc/caddy/conf.d
+caddy::vhost_dir: /etc/caddy/sites-available
+caddy::vhost_enable_dir: /etc/caddy/sites-enabled
+caddy::config_files:
+  admin_port_2020:
+    content: |
+      {
+        admin localhost:2020
+      }
+caddy::vhosts:
+  port_3000:
+    content: |
+      http://localhost:3000 {
+        respond "port 3000"
+      }
+  port_3001:
+    ensure: disabled
+    content: |
+      http://localhost:3001 {
+        respond "port 3001"
+      }
+```
+
 ## Reference
 
 The [reference][1] documentation of this module is generated using [puppetlabs/puppetlabs-strings][2].

--- a/manifests/configfile.pp
+++ b/manifests/configfile.pp
@@ -1,0 +1,54 @@
+# @summary This defined type handles a Caddy config file
+#
+# @param ensure
+#   Make the config file either present or absent.
+#
+# @param source
+#   Source (path) for the caddy config file.
+#
+# @param content
+#   String with the caddy config file.
+#
+# @param config_dir
+#   Where to store the config file.
+#
+# @example Configure Caddy logging
+#   caddy::configfile { 'subdomain-log':
+#     source => 'puppet:///modules/caddy/etc/caddy/config/logging.conf',
+#   }
+#
+# @example Same as above but using content
+#   $log_config = @(SUBDOMAIN_LOG)
+#     (subdomain-log) {
+#       log {
+#         hostnames {args[0]}
+#         output file /var/log/caddy/{args[0]}.log
+#       }
+#     }
+#     | SUBDOMAIN_LOG
+#
+#   caddy::configfile { 'subdomain-log':
+#     content => $log_config,
+#   }
+#
+define caddy::configfile (
+  Enum['present','absent'] $ensure = 'present',
+  Optional[Stdlib::Filesource] $source = undef,
+  Optional[String] $content = undef,
+  Stdlib::Absolutepath $config_dir = $caddy::config_dir,
+) {
+  include caddy
+
+  if ($ensure == 'present') and !($source or $content) {
+    fail('Either $source or $content must be specified when $ensure is "present"')
+  }
+
+  file { "${config_dir}/${title}.conf":
+    ensure  => stdlib::ensure($ensure, 'file'),
+    content => $content,
+    source  => $source,
+    mode    => '0444',
+    require => Class['caddy::config'],
+    notify  => Class['caddy::service'],
+  }
+}

--- a/spec/defines/configfile_spec.rb
+++ b/spec/defines/configfile_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-describe 'caddy::vhost', type: :define do
+describe 'caddy::configfile', type: :define do
   on_supported_os.each do |os, facts|
     context "on #{os}" do
       let(:facts) do
@@ -25,37 +25,9 @@ describe 'caddy::vhost', type: :define do
         end
 
         context 'with config_dir set' do
-          let(:params) { super().merge(config_dir: '/etc/caddy/sites-available') }
+          let(:params) { super().merge(config_dir: '/etc/caddy/conf.d') }
 
-          it { is_expected.to contain_file('/etc/caddy/sites-available/example.conf').with_ensure('file') }
-        end
-
-        context 'with enable_dir set' do
-          let(:params) { super().merge(enable_dir: '/etc/caddy/sites-enabled') }
-
-          it { is_expected.to contain_file('/etc/caddy/config/example.conf').with_ensure('file') }
-
-          it do
-            is_expected.to contain_file('/etc/caddy/sites-enabled/example.conf').
-              with_ensure('link').
-              with_target('/etc/caddy/config/example.conf')
-          end
-
-          %w[present disabled].each do |ens|
-            context "with ensure => #{ens}" do
-              let(:params) { super().merge(ensure: ens) }
-
-              it { is_expected.to contain_file('/etc/caddy/config/example.conf').with_ensure('file') }
-              it { is_expected.to contain_file('/etc/caddy/sites-enabled/example.conf').with_ensure('absent') }
-            end
-          end
-
-          context 'with ensure => absent' do
-            let(:params) { super().merge(ensure: 'absent') }
-
-            it { is_expected.to contain_file('/etc/caddy/config/example.conf').with_ensure('absent') }
-            it { is_expected.to contain_file('/etc/caddy/sites-enabled/example.conf').with_ensure('absent') }
-          end
+          it { is_expected.to contain_file('/etc/caddy/conf.d/example.conf') }
         end
 
         context 'with ensure => absent' do

--- a/templates/etc/caddy/caddyfile.epp
+++ b/templates/etc/caddy/caddyfile.epp
@@ -1,8 +1,10 @@
 <%- |
-  String[1] $config_dir,
+  Array[String[1]] $include_dirs,
 | -%>
 #
 # THIS FILE IS MANAGED BY PUPPET
 #
 
-import <%= $config_dir %>/*.conf
+<%- $include_dirs.each |$dir| { -%>
+import <%= $dir %>/*.conf
+<%- } -%>

--- a/types/config.pp
+++ b/types/config.pp
@@ -1,0 +1,6 @@
+# @summary Caddy config file type
+type Caddy::Config = Struct[{
+    ensure => Optional[Enum['absent', 'present']],
+    source => Optional[Stdlib::Filesource],
+    content => Optional[String[1]],
+}]

--- a/types/virtualhost.pp
+++ b/types/virtualhost.pp
@@ -1,6 +1,6 @@
 # @summary Caddy virtual host type
 type Caddy::VirtualHost = Struct[{
-    ensure => Optional[Enum['absent', 'present']],
+    ensure => Optional[Enum['present','enabled','disabled','absent']],
     source => Optional[Stdlib::Filesource],
     content => Optional[String[1]],
 }]


### PR DESCRIPTION
This change allows to use the config files layout similar to apache/nginx (`conf.d` and/or `sites-allowed`/`sites-enabled`).