### PR TITLE
chore: use renovate for latest version in tests

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended"
+  ],
+  "addLabels": [
+    "renovate",
+    "dependencies"
+  ],
+  "automerge": false,
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": [
+        "spec/acceptance/*.rb"
+      ],
+      "matchStrings": [
+        "# renovate: depName=(?<depName>[^\\s]+?)\\s+String\\[1\\]\\s+latest_release\\s+=\\s+['\"]?(?<currentValue>[\\w+\\.]*)"
+      ],
+      "datasourceTemplate": "github-releases"
+    }
+  ]
+}

--- a/spec/acceptance/init_spec.rb
+++ b/spec/acceptance/init_spec.rb
@@ -5,7 +5,8 @@ require 'spec_helper_acceptance'
 # The default configuration download the latest available release. In order to
 # avoid to maintain the test suite to match each release, query GitHub API to
 # find the last release.
-latest_release = JSON.parse(URI.open('https://api.github.com/repos/caddyserver/caddy/releases/latest').read)['tag_name']
+# renovate: depName=caddyserver/caddy
+latest_release = 'v2.10.0'
 
 # rubocop:disable RSpec/RepeatedExampleGroupDescription
 describe 'class caddy:' do


### PR DESCRIPTION
if repo has mend app (renovate bot) enabled this will create MRs for new versions of caddy in the tests


