### PR TITLE
chore: make renovate to set skip-changelog label

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -22,5 +22,15 @@
       ],
       "datasourceTemplate": "github-releases"
     }
+  ],
+  "packageRules": [
+    {
+      "matchDepNames": ["caddyserver/caddy"],
+      "labels": [
+        "skip-changelog",
+        "renovate",
+        "dependencies"
+      ],
+    }
   ]
 }


### PR DESCRIPTION
The caddy version is only used in acceptance tests. No reason to add this to the changelog.
